### PR TITLE
Define NOMINMAX macro error prevention

### DIFF
--- a/include/fbow/cpu.h
+++ b/include/fbow/cpu.h
@@ -36,6 +36,7 @@ THE SOFTWARE.
 #else
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
 #   if _WIN32
+#define NOMINMAX
 #include <Windows.h>
 #include <intrin.h>
 #   elif defined(__GNUC__) || defined(__clang__)


### PR DESCRIPTION
`#include Windows.h` can cause a lot of errors with min and max macros
`#define NOMINMAX` before the include fixes this issue (by disabling these macros) and prevents unexpected behaviour in external libraries where the compiler confuses std::min and std::max with the Windows.h macros introduced by including fbow